### PR TITLE
Corrected values ordering when recording in burst mode

### DIFF
--- a/imu.py
+++ b/imu.py
@@ -53,12 +53,13 @@ def SpiReadSensor(spi,autoScale=True):
     resp=SpiDevReadBurst(spi,0x3E)
     arr=array.array('B',resp).tostring()
     values=unpack('>hhhhhhhhhhh', arr)
-    imu.accl.x=values[2]
-    imu.accl.y=values[3]
-    imu.accl.z=values[4]
-    imu.gyro.x=values[5]
-    imu.gyro.y=values[6]
-    imu.gyro.z=values[7]
+	# burst order is: DIAG_STAT, X_GYRO_OUT, Y_GYRO_OUT, Z_GYRO_OUT, X_ACCL_OUT, Y_ACCL_OUT, Z_ACCL_OUT, TEMP_OUT
+    imu.gyro.x=values[2]
+    imu.gyro.y=values[3]
+    imu.gyro.z=values[4]
+    imu.accl.x=values[5]
+    imu.accl.y=values[6]
+    imu.accl.z=values[7]
     imu.temp=values[8]
     if autoScale == True:
         imu.scaling()


### PR DESCRIPTION
Hey,

Thanks for putting this up!  It's been a great use to me as I work through getting my IMU running.

I believe the order the sensor values were being read in the burst mode is wrong.  The documentation says it will return the gyro first then accelerometer.  ([ADIS16460 data sheet](https://www.analog.com/media/en/technical-documentation/data-sheets/ADIS16460.pdf), page 11)  I corrected that and the output looks reasonable to me.

Thanks again for your hard work!